### PR TITLE
format stack.yaml for recent version of stack (e.g 2.1.3)

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,13 +4,9 @@ flags:
 # build:
 #   library-profiling: true
 #   executable-profiling: true
-packages:
-- .
-- location:
-    git: http://www.github.com/Mokosha/netwire-input-glfw.git
-    commit: 0f04a165c88087615ba5aa66ce90f9138e9fc7f7
-  extra-dep: true
 extra-deps:
 - GLFW-b-3.2.1.0
 - bindings-GLFW-3.2.1.1
+- git: http://www.github.com/Mokosha/netwire-input-glfw.git
+  commit: 0f04a165c88087615ba5aa66ce90f9138e9fc7f7
 resolver: lts-11.6


### PR DESCRIPTION
`stack.yaml` causes an error in the most recent version of stack. See section "Legacy syntax" at http://docs.haskellstack.org/en/stable/yaml_configuration/.

This is a fix and I am pretty sure it should work for all recent versions of stack.